### PR TITLE
Ignore hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The folder `public/heroku_pages` is assumed to be present in your project.
 
 Remote folder `heroku_pages` on your S3 bucket will be created and all files uploaded to it will be made public.
 
+**Note**: All hidden files (files starting with `.`) is excluded from uploading.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The folder `public/heroku_pages` is assumed to be present in your project.
 
 Remote folder `heroku_pages` on your S3 bucket will be created and all files uploaded to it will be made public.
 
-**Note**: All hidden files (files starting with `.`) is excluded from uploading.
+**Note**: Any hidden files (files starting with .) will not be uploaded
 
 ## Contributing
 

--- a/lib/heroku/command/pages.rb
+++ b/lib/heroku/command/pages.rb
@@ -51,7 +51,7 @@ class Heroku::Command::Pages < Heroku::Command::Base
     ENV['AWS_ACCESS_KEY_ID']     = @key
     ENV['AWS_SECRET_ACCESS_KEY'] = @secret
 
-    run("aws s3 cp #{LOCAL_FOLDER} s3://#{@bucket}/#{REMOTE_FOLDER} --recursive --acl public-read")
+    run("aws s3 cp #{LOCAL_FOLDER} s3://#{@bucket}/#{REMOTE_FOLDER} --recursive --acl public-read --exclude '.*'")
 
     if $?.success?
       display("\e[92mUpload successful.\e[0m")


### PR DESCRIPTION
Exclude all hidden files when copying to S3. 

References Issue #7 
This could perhaps be optional? Couldn't figure out how to send it as a param. 

Not sure if there are other files that start with `.` that should be sent to amazon that this PR could potentially screw up... 
